### PR TITLE
Add duration in traffic methods

### DIFF
--- a/src/Response/Element.php
+++ b/src/Response/Element.php
@@ -63,4 +63,20 @@ class Element
     {
         return ! empty($this->element['duration']['text']) ? $this->element['duration']['text'] : null;
     }
+
+    /**
+     * @return mixed
+     */
+    public function durationInTraffic()
+    {
+        return ! empty($this->element['duration_in_traffic']['value']) ? $this->element['duration_in_traffic']['value'] : null;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function durationInTrafficText()
+    {
+        return ! empty($this->element['duration_in_traffic']['text']) ? $this->element['duration_in_traffic']['text'] : null;
+    }
 }


### PR DESCRIPTION
When using setDepartureTime() for the request the 'duration_in_traffic' elements are present in the response.