### PR TITLE
Feature/add duration in traffic and modify json is public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 vendor/
 composer.lock
 .env
+
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: php
 php:
   - '7.0'
   - '7.1'
-  - nightly
 
 before_script: composer install
-script: phpunit --configuration phpunit.xml
+script: ./vendor/bin/phpunit
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $request = DistanceMatrix::license($license);
 $response = DistanceMatrix::license($license)
     ->addOrigin('norwich,gb')
     ->addDestination('52.603669, 1.223785')
-    ->response();
+    ->request();
    
 // I want to make the following but of API better,
 // as it looks horrible at the moment.
@@ -116,4 +116,12 @@ $distance = $element->distance();
 $distanceText = $element->distanceText();
 $duration = $element->duration();
 $durationText = $element->durationText();
+$durationInTraffic = $element->durationInTraffic();
+$durationInTrafficText = $element->durationInTrafficText();
+
+// or
+
+$response->json['destination_addresses'][0];
+$response->json['rows'][0]['elements'][0]['distance']['value'];
+$response->json['rows'][0]['elements'][0]['duration_in_traffic']['text'];
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There is support for both the Standard License and Premium/Enterprise License ty
 Install the package using composer:
 
 ```
-$ composer require teampickr/php-google-maps-distance-matrix
+$ composer require medeirosdev/php-google-maps-distance-matrix
 ```
 
 ## Frameworks

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There is support for both the Standard License and Premium/Enterprise License ty
 Install the package using composer:
 
 ```
-$ composer require medeirosdev/php-google-maps-distance-matrix
+$ composer require teampickr/php-google-maps-distance-matrix
 ```
 
 ## Frameworks

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
     "guzzlehttp/guzzle": "^6.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.0",
+    "phpunit/phpunit": "6.0",
     "vlucas/phpdotenv": "^2.4",
-    "illuminate/support": "^5.4||^5.5||^5.6"
+    "illuminate/support": ">5.4"
   },
   "suggest": {
     "illuminate/support": "Allows you to use this package from within Laravel"

--- a/src/Response/DistanceMatrixResponse.php
+++ b/src/Response/DistanceMatrixResponse.php
@@ -21,7 +21,7 @@ class DistanceMatrixResponse
     /**
      * @var array
      */
-    protected $json;
+    public $json;
 
     /**
      * DistanceMatrixResponse constructor.
@@ -37,7 +37,7 @@ class DistanceMatrixResponse
     /**
      * @return bool
      */
-    public function successful()
+    public function successful(): bool
     {
         return $this->json['status'] === static::RESPONSE_OKAY;
     }
@@ -73,7 +73,7 @@ class DistanceMatrixResponse
     /**
      * @return array
      */
-    public function origins()
+    public function origins(): array
     {
         return $this->json["origin_addresses"];
     }
@@ -81,7 +81,7 @@ class DistanceMatrixResponse
     /**
      * @return array
      */
-    public function destinations()
+    public function destinations(): array
     {
         return $this->json["destination_addresses"];
     }
@@ -89,7 +89,7 @@ class DistanceMatrixResponse
     /**
      * @return array
      */
-    public function rows()
+    public function rows(): array
     {
         $rows = $this->json['rows'];
 
@@ -105,7 +105,7 @@ class DistanceMatrixResponse
     /**
      * @param int $row
      *
-     * @return \TeamPickr\DistanceMatrix\Response\Row
+     * @return null|\TeamPickr\DistanceMatrix\Response\Row
      */
     public function row(int $row = 0)
     {

--- a/src/Response/Element.php
+++ b/src/Response/Element.php
@@ -27,13 +27,13 @@ class Element
     /**
      * @return bool
      */
-    public function successful()
+    public function successful(): bool
     {
         return $this->element['status'] == static::STATUS_OKAY;
     }
 
     /**
-     * @return mixed
+     * @return null|int
      */
     public function distance()
     {
@@ -41,7 +41,7 @@ class Element
     }
 
     /**
-     * @return mixed
+     * @return null|string
      */
     public function distanceText()
     {
@@ -49,18 +49,33 @@ class Element
     }
 
     /**
-     * @return mixed
+     * @return null|int
      */
     public function duration()
     {
-        return ! empty($this->element['duration']['value']) ? $this->element['duration']['value'] : null;
+        return ! empty($this->element['duration']['value']) ? (int) $this->element['duration']['value'] : null;
     }
 
     /**
-     * @return mixed
+     * @return null|string
      */
     public function durationText()
     {
-        return ! empty($this->element['duration']['text']) ? $this->element['duration']['text'] : null;
+        return ! empty($this->element['duration']['text']) ? (string) $this->element['duration']['text'] : null;
+    }
+
+    /**
+     * @return null|int
+     */
+    public function durationInTraffic()
+    {
+        return ! empty($this->element['duration_in_traffic']['value']) ? (int) $this->element['duration_in_traffic']['value'] : null;
+    }
+    /**
+     * @return null|string
+     */
+    public function durationInTrafficText()
+    {
+        return ! empty($this->element['duration_in_traffic']['text']) ? (string) $this->element['duration_in_traffic']['text'] : null;
     }
 }

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -66,4 +66,15 @@ abstract class AbstractTestCase extends TestCase
         ]);
     }
 
+
+    /**
+     * @return \GuzzleHttp\Handler\MockHandler
+     */
+    public function makeSuccessfulWithDurationInTrafficMockHandler()
+    {
+        return new MockHandler([
+            new Response(200, [], file_get_contents(__DIR__ . '/responses/with_duration_in_traffic.json')),
+        ]);
+    }
+
 }

--- a/tests/DistanceMatrixRequestTest.php
+++ b/tests/DistanceMatrixRequestTest.php
@@ -168,4 +168,30 @@ class DistanceMatrixRequestTest extends AbstractTestCase
         $this->assertTrue($response->successful());
         $this->assertNotNull($response->successful());
     }
+
+
+    /** @test */
+    public function return_duration_in_traffic_request()
+    {
+        $date = 'now';
+
+        $distanceMatrix = $this->newInstance()
+            ->addOrigin('Campinas, SP, BR')
+            ->addDestination('Campinas - SP, Brasil')
+            ->setArrivalTime($date);
+
+        $response = $this->makeTestRequest($distanceMatrix, $this->makeSuccessfulWithDurationInTrafficMockHandler())->request();
+        $element = $response->rows()[0]->elements()[0];
+
+        $request = $this->container[0]['request'];
+
+        $this->assertContains("arrival_time=" . $date, $request->getUri()->getQuery());
+        $this->assertInstanceOf(DistanceMatrixResponse::class, $response);
+        $this->assertTrue($response->successful());
+        $this->assertNotNull($response->successful());
+        $this->assertInstanceOf(Element::class, $element);
+        $this->assertEquals(5496, $element->durationInTraffic());
+        $this->assertEquals('1 hora 32 minutos', $element->durationInTrafficText());
+
+    }
 }

--- a/tests/PremiumLicenseTest.php
+++ b/tests/PremiumLicenseTest.php
@@ -2,6 +2,8 @@
 
 namespace TeamPickr\DistanceMatrix\Tests;
 
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use TeamPickr\DistanceMatrix\DistanceMatrix;
 use TeamPickr\DistanceMatrix\Licenses\PremiumLicense;
@@ -18,7 +20,9 @@ class PremiumLicenseTest extends AbstractTestCase
             ->addOrigin('norwich,gb')
             ->addDestination('ipswich,gb');
 
-        $this->makeTestRequest($distanceMatrix)->request();
+        $mock = new MockHandler([new Response(200)]);
+
+        $this->makeTestRequest($distanceMatrix, $mock)->request();
 
         $request = $this->container[0]['request'];
 

--- a/tests/responses/with_duration_in_traffic.json
+++ b/tests/responses/with_duration_in_traffic.json
@@ -1,0 +1,26 @@
+{
+  "destination_addresses" : [ "São Paulo, SP, Brasil" ],
+  "origin_addresses" : [ "Campinas - SP, Brasil" ],
+  "rows" : [
+    {
+      "elements" : [
+        {
+          "distance" : {
+            "text" : "95,8 km",
+            "value" : 95845
+          },
+          "duration" : {
+            "text" : "1 hora 14 minutos",
+            "value" : 4445
+          },
+          "duration_in_traffic" : {
+            "text" : "1 hora 32 minutos",
+            "value" : 5496
+          },
+          "status" : "OK"
+        }
+      ]
+    }
+  ],
+  "status" : "OK"
+}


### PR DESCRIPTION
**Feature/add duration in traffic and modify json is public**


**Problem**
- unable to recover `duration_in_traffic`


**Solution**
- Create method `durationInTraffic` in `Element` class
- Modify accessor `json` in  `DistanceMatrixResponse` to public to accesses all attributes


**Refactor**
- Define return type in method classes `DistanceMatrixResponse` and `Element `
- Add .idea folder in .gitignore
- Readme.md change request to response
- Add Readme.md example get `durationInTraffic` and `durationInTrafficText`
- Add Readme.md example get `json`  response


**Added Tests**
- return_duration_in_traffic_request in `DistanceMatrixRequestTest` for test `Element`.`durationInTraffic`